### PR TITLE
Some best practices for PSM1

### DIFF
--- a/PSPKIAudit.psm1
+++ b/PSPKIAudit.psm1
@@ -17,13 +17,13 @@ try {
     Import-Module "$($PSScriptRoot)\PSPKI\3.7.2\PSPKI.psm1" -ErrorAction Stop -Force
 } catch {
     Write-Warning "Unable to load PSPKI: $_"
-    exit(1)
+    return
 }
 
 # Ensure the version of PSPKI that comes bundled here is used and not the one from the gallery
 if(![SysadminsLV.PKI.Win32.Crypt32].Assembly.Location.Contains($PSScriptRoot)) {
     Write-Warning "The wrong version of PSPKI is loaded. Please open a new PowerShell window and reload this module."
-    exit(1)
+    return
 }
 
 
@@ -32,7 +32,7 @@ try {
 }
 catch {
     Write-Warning "Please install the ActiveDirectory module'"
-    exit(1)
+    return
 }
 
 Get-ChildItem -Path "$($PSScriptRoot)\Code\" -Recurse -Include *.ps1 | % { Import-Module $_.FullName -DisableNameChecking -Force }

--- a/PSPKIAudit.psm1
+++ b/PSPKIAudit.psm1
@@ -35,4 +35,4 @@ catch {
     return
 }
 
-Get-ChildItem -Path "$($PSScriptRoot)\Code\" -Recurse -Include *.ps1 | ForEach-Object { Import-Module $_.FullName -DisableNameChecking -Force }
+Get-ChildItem -Path "$($PSScriptRoot)\Code\" -Recurse -Include *.ps1 | ForEach-Object { . $_.FullName }

--- a/PSPKIAudit.psm1
+++ b/PSPKIAudit.psm1
@@ -35,4 +35,4 @@ catch {
     return
 }
 
-Get-ChildItem -Path "$($PSScriptRoot)\Code\" -Recurse -Include *.ps1 | % { Import-Module $_.FullName -DisableNameChecking -Force }
+Get-ChildItem -Path "$($PSScriptRoot)\Code\" -Recurse -Include *.ps1 | ForEach-Object { Import-Module $_.FullName -DisableNameChecking -Force }


### PR DESCRIPTION
- Replaces Exit with Return to prevent user confusion when terminal just ends - in case module is missing
- Expands ForEach-Object alias so users can easier understand what happens
- Replaces Import-Module with dot-sourcing

I've not touched the Import-Module of PSPKI since I have never used it, but here are some thoughts I have about it:

- You should always import PSD1, not PSM1, as it defines a lot of additional actions that may be necessary for the module to work properly. While it may work for you this time, it's not always the case
- Consider using Required modules in PSD1 for PSPKI which when defined this way will allow you to skip checking if that module loads or not, as when using `Import-Module PSPKIAudit` would trigger the first check for PSPKI and fail if it doesn't exist. I know you're bundling it up, but consider adding it to the required module which when you publish `PSPKIAudit` to PowerShellGallery will be automatically downloaded with your module. PSPKI is already there - consider using it (https://www.powershellgallery.com/packages/PSPKI/3.7.2). It's much easier for users to use modules from PSGallery directly. 