### PR TITLE
Update $CommonLowprivPrincipals

### DIFF
--- a/Code/Invoke-PKIAudit.ps1
+++ b/Code/Invoke-PKIAudit.ps1
@@ -6,7 +6,7 @@ $Version = "0.3.6"
 #   Domain Users            S-1-5-21domain-513
 #   Domain Computers        S-1-5-21domain-515
 #   Users                   S-1-5-32-545
-$CommonLowprivPrincipals = "S-1-1-0|S-1-5-11|S-1-5-21.*-513|S-1-5-21.*-515|S-1-5-32-545"`
+$CommonLowprivPrincipals = "S-1-1-0|S-1-5-11|S-1-5-21.*-513$|S-1-5-21.*-515$|S-1-5-32-545"`
 
 # cache for username->SID translations
 $SIDTranslationCache = @{}


### PR DESCRIPTION
The patterns defined in $CommonLowprivPrincipals cause the script to mistakenly identify the CA and templates as vulnerable if the domain portion of the SID contains -513 or -515. Modified the variable to specify that -513 and -515 must appear at the end of the SID.