### PR TITLE
Check if current user is a member of the Protected Users group

### DIFF
--- a/Code/Invoke-PKIAudit.ps1
+++ b/Code/Invoke-PKIAudit.ps1
@@ -97,6 +97,10 @@ function Invoke-PKIAudit {
             Write-Host -ForegroundColor Red "[!] The above CA is misconfigured!"
         }
 
+        if (Test-IsMemberOfProtectedUsers) {
+            Write-Warning -WarningAction Continue -Message "The current user is a member of the Protected Users group, which will cause anything with dependencies on NTLM to fail. Please keep this in mind for ESC8 checks."
+        }
+
         # get the set of templates published to this CA (or all templates if -ShowAllVulnerableTemplates is passed)
         $CATemplates = Get-AuditCertificateTemplate @Args
         


### PR DESCRIPTION
This PR adds a check to see if the current user is a member of the Protected Users group. If true, it will warn the user that anything relying on NTLM authentication (eg: ESC8) may have problems. Provides a partial resolution to #4.

Feel free to use all or any part of these two commits. 🫡