### PR TITLE
Fixes and documents Test-IsMemberOfProtectedUsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2024-02-16
+
+* Fixed function to test if current user is a member of Protected Users
+
 ## [0.3.7] - 2023-02-08
 
 * Fix manifest to include RootModule 

--- a/Code/Invoke-PKIAudit.ps1
+++ b/Code/Invoke-PKIAudit.ps1
@@ -1,4 +1,4 @@
-$Version = "0.3.6"
+$Version = "0.3.8"
 
 # regex of low-privileged principal names used for testing vulnerable enrollment/access control
 #   Everyone                S-1-1-0

--- a/Code/Invoke-PKIAudit.ps1
+++ b/Code/Invoke-PKIAudit.ps1
@@ -891,75 +891,80 @@ function Format-PKIAdObjectControllers {
 function Test-IsMemberOfProtectedUsers {
     <#
         .SYNOPSIS
-        Check to see if the current user in this execution context is a member of the Protected Users group.
-    
+            Check to see if a user is a member of the Protected Users group.
+
         .DESCRIPTION
-        This function checks to see if the current user who executes the script is a member of the Protected Users group.
-        It returns true or false, depending on the result. 
-    
+            This function checks to see if a specified user or the current user is a member of the Protected Users group in AD.
+            It also checked the user's primary group ID in case that is set to 525 (Protected Users).
+
         .PARAMETER User
-        The username (SamAccountName) that will be checked for membership in the Protected Users group.
+            The user that will be checked for membership in the Protected Users group. This parameter accepts input from the pipeline.
 
         .EXAMPLE
-        This example will check if JaneDoe is a member of the Protected Users group.
-        
+            This example will check if JaneDoe is a member of the Protected Users group.
+
             Test-IsMemberOfProtectedUsers -User JaneDoe
 
         .EXAMPLE
-        This example will check if the current user is a member of the Protected Users group.
-        
+            This example will check if the current user is a member of the Protected Users group.
+
             Test-IsMemberOfProtectedUsers
-    
+
         .INPUTS
-        String: SamAccountName
-    
+            Active Directory user object, user SID, SamAccountName, etc
+
         .OUTPUTS
-        Boolean
+            True, False
 
         .NOTES
-        This can have implications for anything that relies on NTLM authentication.
-        Keep in mind the effects of using run-as with a different user than what you are currently logged in as.
+            Author:     Sam Erde
+            Base Repo:  https://github.com/SamErde/Active-Directory
+            Modified:   2024-02-16
+            Version:    0.1.0
 
+            Membership in Active Directory's Protect Users group can have implications for anything that relies on NTLM authentication.
     #>
-    
-        [CmdletBinding()]
-        param (
-            [Parameter(
-                ValueFromPipeline = $false
-            )]
-            [string]$User
-        )
-    
-        Import-Module ActiveDirectory
-    
-        # If a user is specified, check and remove any "DomainName\" prefix, leaving only the SamAccountName
-        if ($User) {
-            # Remove the domain name from the username string if it was included
-            if ($User -like "*\*") {
-                $UserName = ( $User.Split('\') )[-1]
-            }
-            else {
-                $UserName = $User
-            }
-        }
-        # Use the currently logged in user if none is specified
-        else {
-            $CurrentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-            $UserName = ($CurrentUser.Split('\')[-1])
-        }
 
-        # Get the SID of the Protected Users group to ensure compatibility with any locale's language.
-        $DomainSID = (Get-ADDomain).DomainSID.Value
-        $ProtectedUsersSID = "$DomainSID-525"
-    
-        # Get members of the Protected Users group for the current domain.
-        $ProtectedUsers = Get-ADGroupMember -Identity $ProtectedUsersSID -Recursive |
-            Select-Object -Unique -ExpandProperty SamAccountName
-    
-        # Check if the current user is in the 'Protected Users' group
-        if ($ProtectedUsers -contains $UserName) {
+    [CmdletBinding()]
+    param (
+        # User parameter accepts any input that is valid for Get-ADUser
+        [Parameter(
+            ValueFromPipeline = $true
+        )]
+        $User
+    )
+
+    Import-Module ActiveDirectory
+
+    # Use the currently logged in user if none is specified
+    # Get the user from Active Directory
+    if (-not($User)) {
+        # These two are different types. Fixed by referencing $CheckUser.SID later, but should fix here by using one type.
+        $CurrentUser = ([System.Security.Principal.WindowsIdentity]::GetCurrent().Name).Split('\')[-1]
+        $CheckUser = Get-ADUser $CurrentUser -Properties primaryGroupID
+    }
+    else {
+        $CheckUser = Get-ADUser $User -Properties primaryGroupID
+    }
+
+    # Get the Protected Users group by SID instead of by its name to ensure compatibility with any locale or language.
+    $DomainSID = (Get-ADDomain).DomainSID.Value
+    $ProtectedUsersSID = "$DomainSID-525"
+
+    # Get members of the Protected Users group for the current domain. Recuse in case groups are nested in it.
+    $ProtectedUsers = Get-ADGroupMember -Identity $ProtectedUsersSID -Recursive | Select-Object -Unique
+
+    # Check if the current user is in the 'Protected Users' group
+    if ($ProtectedUsers.SID.Value -contains $CheckUser.SID) {
+        Write-Verbose "$($CheckUser.Name) ($($CheckUser.DistinguishedName)) is a member of the Protected Users group."
+        $true
+    } else {
+        # Check if the user's PGID (primary group ID) is set to the Protected Users group RID (525).
+        if ( $CheckUser.primaryGroupID -eq '525' ) {
             $true
         } else {
+            Write-Verbose "$($CheckUser.Name) ($($CheckUser.DistinguishedName)) is not a member of the Protected Users group."
             $false
         }
     }
+}

--- a/README.md
+++ b/README.md
@@ -542,6 +542,9 @@ Go to "Security" and remove the vulnerable access control entry.
 
 **NOTE:** this particular check in PSPKIAudit only checks if NTLM is present for any published enrollment endpoints. *It does NOT check if Extended Protection for Authentication is present for these NTLM-enabled endoints, so false positives may occur!*
 
+> [!IMPORTANT]  
+> NTLM authentication is disabled for accounts in the Protected Users group. This check may fail if running PSPKIAudit while logged in as a Protected User.
+
 ### Details <!-- omit in toc -->
 
 AD CS supports several HTTP-based enrollment methods via additional AD CS server roles that administrators can install. These HTTP-based certificate enrollment interfaces are all vulnerable NTLM relay attacks.


### PR DESCRIPTION
Fixed two issues in Test-IsMemberOfProtectedUsers. Added additional check for primary group ID. The function is maintained at https://github.com/SamErde/Active-Directory.

Added note to README about NTLM and Protected Users potentially affecting ESC8 checks.

Incremented hotfix version with notes in CHANGELOG.

Caught up version number in module to match changelog.