### PR TITLE
Fix ESC1 false negatives in template enumeration

### DIFF
--- a/Code/Invoke-PKIAudit.ps1
+++ b/Code/Invoke-PKIAudit.ps1
@@ -401,7 +401,7 @@ function Get-AuditCertificateTemplate {
     if($ShowAllVulnerableTemplates) {
         ForEach($CATemplate in $Templates) {
             $CATemplateACL = $CATemplate | Get-CertificateTemplateAcl
-            $DACLString = (($CATemplateACL.Access | ForEach-Object { "$($_.IdentityReference) ($($_.AccessControlType)) - $($_.Rights)"}) -join "`n")
+            $DACLString = Get-CertificateTemplateDACLString -TemplateDistinguishedName $CATemplate.DistinguishedName
             $IsTemplateACLVulnerable = Test-IsCertificateTemplateACLVulnerable $CATemplateACL
             $CanLowPrivEnrollInTemplate = Test-CanLowPrivEnrollInTemplate -TemplateDistinguishedName $CATemplate.DistinguishedName
             $EnrolleeSuppliesSubject = $CATemplate.Settings.SubjectName.HasFlag([PKI.CertificateTemplates.CertificateTemplateNameFlags]::EnrolleeSuppliesSubject)
@@ -454,7 +454,7 @@ function Get-AuditCertificateTemplate {
             try {
                 ForEach($CATemplate in $CATemplates) {
                     $CATemplateACL = $CATemplate | Get-CertificateTemplateAcl
-                    $DACLString = (($CATemplateACL.Access | ForEach-Object { "$($_.IdentityReference) ($($_.AccessControlType)) - $($_.Rights)"}) -join "`n")
+                    $DACLString = Get-CertificateTemplateDACLString -TemplateDistinguishedName $CATemplate.DistinguishedName
                     $IsTemplateACLVulnerable = Test-IsCertificateTemplateACLVulnerable $CATemplateACL
                     $CanLowPrivEnrollInTemplate = Test-CanLowPrivEnrollInTemplate -TemplateDistinguishedName $CATemplate.DistinguishedName
                     $EnrolleeSuppliesSubject = $CATemplate.Settings.SubjectName.HasFlag([PKI.CertificateTemplates.CertificateTemplateNameFlags]::EnrolleeSuppliesSubject)
@@ -726,6 +726,47 @@ function Test-CanLowPrivEnrollInTemplate {
     return $False
 }
 
+
+function Get-CertificateTemplateDACLString {
+    <#
+    .SYNOPSIS
+    
+    Builds a human-readable DACL string for a certificate template using ActiveDirectory.
+    
+    License: Ms-PL
+    Required Dependencies: ActiveDirectory
+    
+    .PARAMETER TemplateDistinguishedName
+    The DN of the certificate template.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Position=0, Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $TemplateDistinguishedName
+    )
+
+    $AdObj = Get-ADObject -Identity $TemplateDistinguishedName -Properties nTSecurityDescriptor
+    $Sd = $AdObj.nTSecurityDescriptor
+    $Dacl = $Sd.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+
+    $lines = @()
+    foreach($Ace in $Dacl) {
+        $rights = $Ace.ActiveDirectoryRights
+        $type = $Ace.AccessControlType
+
+        $sid = $Ace.IdentityReference.Value
+        $ntName = $null
+        try { $ntName = ($Ace.IdentityReference.Translate([System.Security.Principal.NTAccount])).Value } catch {}
+
+        if(-not [string]::IsNullOrEmpty($ntName)) { $idStr = $ntName } else { $idStr = $sid }
+
+        $lines += ("$idStr ($type) - $rights")
+    }
+
+    return ($lines -join "`n")
+}
 
 function Test-UserSpecifiesSAN {
     <#

--- a/Code/Invoke-PKIAudit.ps1
+++ b/Code/Invoke-PKIAudit.ps1
@@ -403,7 +403,7 @@ function Get-AuditCertificateTemplate {
             $CATemplateACL = $CATemplate | Get-CertificateTemplateAcl
             $DACLString = (($CATemplateACL.Access | ForEach-Object { "$($_.IdentityReference) ($($_.AccessControlType)) - $($_.Rights)"}) -join "`n")
             $IsTemplateACLVulnerable = Test-IsCertificateTemplateACLVulnerable $CATemplateACL
-            $CanLowPrivEnrollInTemplate = Test-CanLowPrivEnrollInTemplate $CATemplateACL
+            $CanLowPrivEnrollInTemplate = Test-CanLowPrivEnrollInTemplate -TemplateDistinguishedName $CATemplate.DistinguishedName
             $EnrolleeSuppliesSubject = $CATemplate.Settings.SubjectName.HasFlag([PKI.CertificateTemplates.CertificateTemplateNameFlags]::EnrolleeSuppliesSubject)
 
             # Client Authentication - 1.3.6.1.5.5.7.3.2
@@ -456,7 +456,7 @@ function Get-AuditCertificateTemplate {
                     $CATemplateACL = $CATemplate | Get-CertificateTemplateAcl
                     $DACLString = (($CATemplateACL.Access | ForEach-Object { "$($_.IdentityReference) ($($_.AccessControlType)) - $($_.Rights)"}) -join "`n")
                     $IsTemplateACLVulnerable = Test-IsCertificateTemplateACLVulnerable $CATemplateACL
-                    $CanLowPrivEnrollInTemplate = Test-CanLowPrivEnrollInTemplate $CATemplateACL
+                    $CanLowPrivEnrollInTemplate = Test-CanLowPrivEnrollInTemplate -TemplateDistinguishedName $CATemplate.DistinguishedName
                     $EnrolleeSuppliesSubject = $CATemplate.Settings.SubjectName.HasFlag([PKI.CertificateTemplates.CertificateTemplateNameFlags]::EnrolleeSuppliesSubject)
 
                     # Client Authentication - 1.3.6.1.5.5.7.3.2
@@ -617,33 +617,109 @@ function Test-IsCertificateAuthorityACLVulnerable {
 }
 
 
+function Get-AdminSids {
+    <#
+    .SYNOPSIS
+    
+    Returns a set of SIDs considered administrative/privileged in the forest.
+    
+    License: Ms-PL
+    Required Dependencies: ActiveDirectory
+    #>
+    [CmdletBinding()]
+    Param()
+
+    $adminSids = New-Object 'System.Collections.Generic.HashSet[string]'
+
+    # Built-in well-known SIDs
+    $null = $adminSids.Add('S-1-5-9')           # Enterprise Domain Controllers
+    $null = $adminSids.Add('S-1-5-32-544')     # BUILTIN\Administrators
+
+    # Current domain
+    $currentDomain = Get-ADDomain
+    $currentDomainSid = $currentDomain.DomainSID.Value
+
+    foreach($rid in 500, 502, 512, 516, 521) {
+        $null = $adminSids.Add("$currentDomainSid-$rid")
+    }
+
+    # Forest root domain groups
+    $forest = Get-ADForest
+    $rootDomain = Get-ADDomain -Identity $forest.RootDomain
+    $rootSid = $rootDomain.DomainSID.Value
+
+    foreach($rid in 498, 518, 519) {
+        $null = $adminSids.Add("$rootSid-$rid")
+    }
+
+    # Expand members (recursive) for all known admin group SIDs
+    $groupSids = @(
+        "$currentDomainSid-512", # Domain Admins
+        "$currentDomainSid-516", # Domain Controllers
+        "$currentDomainSid-521", # Read-only Domain Controllers
+        "$rootSid-498",          # Enterprise Read-only Domain Controllers
+        "$rootSid-518",          # Schema Admins
+        "$rootSid-519"           # Enterprise Admins
+    )
+
+    foreach($gSid in $groupSids) {
+        try {
+            foreach($m in (Get-ADGroupMember -Identity $gSid -Recursive -ErrorAction Stop)) {
+                if($null -ne $m.SID) { $null = $adminSids.Add($m.SID.Value) }
+            }
+        } catch {
+            # Group might not exist in this environment; ignore
+        }
+    }
+
+    return [string[]]$adminSids
+}
+
+
 function Test-CanLowPrivEnrollInTemplate {
     <#
     .SYNOPSIS
     
     Returns true if default low privileged principals can enroll in a template.
-
+    Implements MS-CRTD processing rules for enroll rights.
+    
     License: Ms-PL
-    Required Dependencies: PSPKI
+    Required Dependencies: ActiveDirectory
+    
+    .PARAMETER TemplateDistinguishedName
 
-    .PARAMETER TemplateACL
-
-    The certificate template ACL to audit.
+    Distinguished name of the template to read raw AD ACL for precise ACE checks.
     #>
     [CmdletBinding()]
     Param(
         [Parameter(Position=0, Mandatory=$True)]
-        [SysadminsLV.PKI.Security.AccessControl.CertTemplateSecurityDescriptor]
-        $TemplateACL
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $TemplateDistinguishedName
     )
     
-    ForEach($Ace in $TemplateACL.Access) {
-        if(
-            ($Ace.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow) -and 
-            ( (ConvertName-ToSid $Ace.IdentityReference) -match $CommonLowprivPrincipals) -and 
-            ($Ace.Rights.HasFlag([SysadminsLV.PKI.Security.AccessControl.CertTemplateRights]::Enroll))
-        ) {
-            return $True
+    $AdObj = Get-ADObject -Identity $TemplateDistinguishedName -Properties nTSecurityDescriptor
+    $Sd = $AdObj.nTSecurityDescriptor
+    $Dacl = $Sd.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+    $EnrollGuid = [Guid]'0e10c968-78fb-11d2-90d4-00c04f79dc55'
+    $ZeroGuid = [Guid]'00000000-0000-0000-0000-000000000000'
+    $AdminSids = Get-AdminSids
+
+    foreach($Ace in $Dacl) {
+        # Only consider allow ACEs for low-privileged principals
+        if($Ace.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow) { continue }
+
+        $AceSid = $Ace.IdentityReference.Value
+        if($AdminSids -contains $AceSid) { continue }
+
+        # Access mask must include ExtendedRight
+        $HasExtendedRight = $Ace.ActiveDirectoryRights.HasFlag([System.DirectoryServices.ActiveDirectoryRights]::ExtendedRight)
+        if(-not $HasExtendedRight) { continue }
+
+        # Evaluate ObjectType handling Enroll GUID and zero-GUID (non-object ACE)
+        if($Ace.ObjectType -ne $null) {
+            if(($Ace.ObjectType -eq $EnrollGuid) -or ($Ace.ObjectType -eq $ZeroGuid)) { return $true }
+            continue
         }
     }
 


### PR DESCRIPTION
# Fix ESC1 false negatives in template enumeration

## Summary
This PR improves ESC1 detection in PSPKIAudit by addressing false negatives observed in specific template configurations. The change refines the logic that determines whether a template is exploitable for ESC1.

## Background
According to Microsoft documentation ([MS-CRTD](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-crtd/4be42fa6-c421-4763-890b-07a9ab5a319d)) enrollment permissions for a certificate template are evaluated based on two processing rules:

**First rule**
- The requester SID matches the SID associated with the ACE.  
- The ACE type is `ACCESS_ALLOWED_OBJECT_ACE`.  
- The access mask has the bit `0x00000100` set (Control Access).  
- The `ObjectType` field corresponds to the Enroll GUID (`0e10c968-78fb-11d2-90d4-00c04f79dc55`).  

**Second rule**
- The requester SID matches the SID associated with the ACE.  
- The ACE type is `ACCESS_ALLOWED_ACE`.  
- The access mask has the bit `0x00000100` set.  

These rules define how Active Directory evaluates whether a principal can enroll for a certificate. In addition to Microsoft’s specification, further practical details and lab-based examples can be found in my previous articles [*The Schrödinger’s ESC1 Vulnerability*](https://medium.com/@vilachamatheus/the-schr%C3%B6dingers-esc1-vulnerability-ec1cee0cd9b8) and [*The Schrödinger’s ESC1 Vulnerability: Benchmark Update*](https://medium.com/@vilachamatheus/the-schr%C3%B6dingers-esc1-vulnerability-benchmark-update-e9a24421850b), where these conditions were analyzed across different tool implementations.

## Problem
In some scenarios, PSPKIAudit failed to flag templates as ESC1-vulnerable even when they were exploitable. This was reproducible in a controlled lab with eight dedicated templates (four vulnerable, four non-vulnerable).

## Root Cause
In `PSPKIAudit/Code/Invoke-PKIAudit.ps1`, the function **`Test-CanLowPrivEnrollInTemplate`** does not implement both enrollment-processing rules defined by Microsoft’s specification (MS-CRTD). The current logic effectively checks only **Rule 1** by validating the presence of the Enroll object-specific extended right. Because an ACE with an `ObjectType` is, by definition, an `ACCESS_ALLOWED_OBJECT_ACE`, the function implicitly assumes the ACE type and does not verify it explicitly.  

As a result, **Rule 2** is not considered. This omission leads to false negatives in cases where enrollment is legitimately granted through a standard ACE with Control Access.

## Solution

### Key changes
- **Implemented MS-CRTD enrollment checks in `PSPKIAudit/Code/Invoke-PKIAudit.ps1`**
  - Rewrote `Test-CanLowPrivEnrollInTemplate` to read the template’s AD ACL by DN and enforce:
    - ACCESS_ALLOWED_OBJECT_ACE with Control Access bit set and ObjectType = Enroll GUID
    - ACCESS_ALLOWED_ACE with Control Access bit set
  - Updated function docs to require ActiveDirectory module (instead of PSPKI).  

- **Replaced low-priv principal regex with non-admin check in `PSPKIAudit/Code/Invoke-PKIAudit.ps1`**
  - Added `Get-AdminSids` to build an admin SID set (well-known SIDs, Administrator, krbtgt, key admin groups, and all their members).
  - `Test-CanLowPrivEnrollInTemplate` now skips ACEs assigned to admin SIDs and evaluates only non-admin principals.  

- **Improved DACL rendering for templates in `PSPKIAudit/Code/Invoke-PKIAudit.ps1`**
  - Added `Get-CertificateTemplateDACLString` to build DACL output from AD (nTSecurityDescriptor), listing entries as “DOMAIN\sam (Allow|Deny) - Rights”.
  - Resolved identities to DOMAIN\sam via NTAccount, falling back to SID if translation fails.  
  - Updated both `Get-AuditCertificateTemplate` code paths to use the new function, fixing incomplete ACL displays seen with `Get-CertificateTemplateAcl`.

### What this means
- Enrollment rights are now determined exactly per **MS-CRTD**:
  - Rule 1: `ACCESS_ALLOWED_OBJECT_ACE` + Control Access + Enroll GUID.  
  - Rule 2: `ACCESS_ALLOWED_ACE` (standard) + Control Access bit.  
- Enrollment permissions are now listed for all low-privileged (non-admin) principals instead of only the ones listed in `CommonLowprivPrincipals`.  
- All the ACEs in the DACL are now printed based on the definitions present in [MS-ADTS](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/990fb975-ab31-4bc1-8b75-5da132cd4584)

This aligns PSPKIAudit’s behavior with the spec and eliminates the observed false negatives for templates that rely on a standard Control Access grant or that grant enrollment permissions to a low-privileged principal not listed in `CommonLowprivPrincipals`.

## Testing

- **Environment:** Terraform + GCP lab consisting of a Domain Controller, a Certificate Authority, a Windows Server (for .exe and .ps1 tools), and an Ubuntu machine (for Python tools).  
- **Vulnerable templates:** Four vulnerable certificate templates, with screenshots of their security descriptors and the corresponding vulnerable ACEs included.  
  - TestCase1
    - ACE Type: ACCESS_ALLOWED_OBJECT_ACE
    - Principal: Domain Users group
    - Access Mask: 0x00000130
    - Object GUID: 0e10c968–78fb-11d2–90d4–00c04f79dc55
  - TestCase2
    - ACE Type: ACCESS_ALLOWED_OBJECT_ACE
    - Principal: Specific low-privileged user (alice)
    - Access Mask: 0x00000130
    - Object GUID: 0e10c968–78fb-11d2–90d4–00c04f79dc55
  - TestCase3
    - ACE Type: ACCESS_ALLOWED_ACE
    - Principal: Domain Users group
    - Access Mask: 0x00000100
  - TestCase4
    - ACE Type: ACCESS_ALLOWED_OBJECT_ACE
    - Principal: Specific low-privileged user (alice)
    - Access Mask: 0x00000100  

- **Reproduction:**  
  1. Run `Invoke-PKIAudit` using the modified version of PSPKIAudit (this branch).  
     <img width="1890" height="341" alt="2025-09-06 16_49_08" src="https://github.com/user-attachments/assets/14a31e4a-1870-48f7-80fd-e7cd8486825f" />  
     <img width="1903" height="531" alt="2025-09-06 17_04_00" src="https://github.com/user-attachments/assets/009bb5f3-f748-4994-afd0-9884bcb11f0b" />    
     <img width="1903" height="420" alt="2025-09-06 17_04_21" src="https://github.com/user-attachments/assets/540b06b5-595d-43b1-bd2d-f3948acb4bb6" />  
     <img width="1903" height="386" alt="2025-09-06 17_04_43" src="https://github.com/user-attachments/assets/090b9fd0-a29e-4db6-a0b0-b8b311b42e57" />  
     <img width="1903" height="387" alt="2025-09-06 17_05_06" src="https://github.com/user-attachments/assets/49a4597c-60dd-4cb7-9a9d-ac1d74d27e93" />  
     <img width="1903" height="450" alt="2025-09-06 17_05_26" src="https://github.com/user-attachments/assets/2172a144-1758-4fb2-8586-15b06306595a" />  

  2. Run the same `Invoke-PKIAudit` command using the original PSPKIAudit release for comparison.    
     <img width="1903" height="342" alt="2025-09-06 17_09_36" src="https://github.com/user-attachments/assets/098551e3-254e-47a0-b4c9-82089f074676" />
     <img width="1903" height="531" alt="2025-09-06 17_22_44" src="https://github.com/user-attachments/assets/4ae11ae3-d660-4b0c-ac7d-b7bd37e86fdf" />  
     <img width="1903" height="469" alt="2025-09-06 17_23_11" src="https://github.com/user-attachments/assets/c1b87962-4680-45b2-bd8c-d8954eb0791e" />  

  3. For the vulnerable cases where the original PSPKIAudit failed to detect ESC1 (false negatives), privilege escalation using certipy req and certipy auth was demonstrated to confirm that the templates were indeed exploitable.    
     <img width="1903" height="420" alt="2025-09-06 17_27_08" src="https://github.com/user-attachments/assets/848490e8-bc2a-4c2b-a62d-6805d9980d4a" />  
     <img width="1903" height="420" alt="2025-09-06 17_28_11" src="https://github.com/user-attachments/assets/5fb26249-ac71-472a-a706-f91e2e629c6a" />  
     <img width="1903" height="420" alt="2025-09-06 17_28_54" src="https://github.com/user-attachments/assets/a0fcd69a-76d0-4459-a7f8-2a6415de9b02" />  

## Result
All four vulnerable templates are now correctly reported as ESC1 by the modified PSPKIAudit.
